### PR TITLE
Make GitHub detect *.cf, *.cfs, and *.aforth as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.cf linguist-language=Forth
+*.cfs linguist-language=Forth
+*.aforth linguist-language=Forth


### PR DESCRIPTION
Hello,

Please merge this, if you'd like GitHub to detect your `.cf`, `.cfs`, and `.aforth` files as Forth.

Thank you!
